### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,13 @@ readme = "README.md"
 default = ["image"]
 
 [dependencies]
-image = { version = "0.19.0", optional = true }
+image = { version = "0.24.4", optional = true }
 
 [dev-dependencies]
 tempfile = "3"
 
 [build-dependencies]
-bindgen = { version = "0.26.3", optional = true }
+bindgen = { version = "0.61.0", optional = true }
 cc = "1.0"
 
 [badges]

--- a/examples/svg_to_png.rs
+++ b/examples/svg_to_png.rs
@@ -20,6 +20,6 @@ fn main() {
     &image.into_raw(),
     width,
     height,
-    image::ColorType::RGBA(8),
+    image::ColorType::Rgba8,
   ).expect("Failed to save png.");
 }


### PR DESCRIPTION
Fixes #4

Updates the version of [`image`](https://docs.rs/crate/image/0.24.4) and [`bindgen`](https://docs.rs/crate/bindgen/0.61.0) to the latest versions.